### PR TITLE
Fix max char limits

### DIFF
--- a/lib/net/dns/names.rb
+++ b/lib/net/dns/names.rb
@@ -54,12 +54,15 @@ module Net # :nodoc:
       end
 
       def pack_name(name)
-        if name.size > 63
-          raise ArgumentError, "Label data cannot exceed 63 chars"
+        if name.size > 255 
+          raise ArgumentError, "Name may not exceed 255 chars"
         end
         arr = name.split(".")
         str = ""
         arr.each do |elem|
+          if elem.size > 63
+            raise ArgumentError, "Label may not exceed 63 chars"
+          end
           str += [elem.size,elem].pack("Ca*")
         end
         str += [0].pack("C")

--- a/test/names_test.rb
+++ b/test/names_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'net/dns/names'
+
+class NamesTest < Test::Unit::TestCase
+  include Net::DNS::Names
+
+  def test_long_names
+    assert_nothing_raised do
+      pack_name('a' * 63)
+    end
+    assert_raise ArgumentError do
+      pack_name('a' * 64)
+    end
+    assert_nothing_raised do
+      pack_name(['a' * 63, 'b' * 63, 'c' * 63, 'd' * 63].join('.'))
+    end
+    assert_raise ArgumentError do
+      pack_name(['a' * 63, 'b' * 63, 'c' * 63, 'd' * 63, 'e'].join('.'))
+    end
+  end
+end


### PR DESCRIPTION
Correct the logic in names that determines the maximum label and domain lengths. Domain name is max 255 chars and labels (which are the parts of the domain between the dots) can be max 63 chars.
