### PR TITLE
SRV record not required by Net::DNS::RR

### DIFF
--- a/lib/net/dns/rr.rb
+++ b/lib/net/dns/rr.rb
@@ -3,7 +3,7 @@ require 'net/dns/rr/types'
 require 'net/dns/rr/classes'
 
 
-%w(a aaaa ns cname hinfo mr mx txt soa ptr).each do |file|
+%w(a aaaa cname hinfo mr mx ns ptr soa srv txt).each do |file|
   require "net/dns/rr/#{file}"
 end
 


### PR DESCRIPTION
The SRV record was omitted from the array of record types to include.
Additionally I sorted the list alphabetically so it in the future is
easier to see if other types are forgotten.
