### PR TITLE
Drop duplicate query ID handling

### DIFF
--- a/lib/net/dns/header.rb
+++ b/lib/net/dns/header.rb
@@ -63,10 +63,6 @@ module Net
       class Error < StandardError
       end
 
-      # The requested ID is already in use.
-      class DuplicateIDError < Error
-      end
-
 
       #
       # = Name
@@ -179,8 +175,6 @@ module Net
       STATUS  = 2
       # Array with given strings
       OPARR = %w[QUERY IQUERY STATUS]
-
-      @@id_arr = []
 
       # Reader for +id+ attribute
       attr_reader :id
@@ -357,12 +351,8 @@ module Net
       # performing security tests.
       #
       def id=(val)
-        if @@id_arr.include? val
-          raise DuplicateIDError, "ID `#{val}' already used"
-        end
         if (1..65535).include? val
           @id = val
-          @@id_arr.push val
         else
           raise ArgumentError, "ID `#{val}' out of range"
         end
@@ -729,10 +719,7 @@ module Net
       end
 
       def genID
-        while (@@id_arr.include?(q = rand(65535)))
-        end
-        @@id_arr.push(q)
-        q
+        rand(65535)
       end
 
     end

--- a/test/header_test.rb
+++ b/test/header_test.rb
@@ -119,9 +119,6 @@ class HeaderTest < Test::Unit::TestCase
     assert_raises(ArgumentError) do
       Header.parse("aa")
     end
-    assert_raises(Header::DuplicateIDError) do
-      @default.id = 441
-    end
     assert_raises(ArgumentError) do
       @default.id = 1000000
     end


### PR DESCRIPTION
Protection against the Kaminsky attack requires query IDs to be
random, but it doesn't require them to be unique. And since net-dns
opens a new socket for each query it performs, it doesn't rely on the
uniqueness of the query ID to map requests to responses.

Requiring unique query IDs limits net-dns to only making 65535 lookups
before it starts spinning in circles, trying to generate a query ID it
hasn't seen before, when in fact they have all been generated.

So instead, generate random query IDs, but don't require them to be
unique.
