### PR TITLE
Changed range for valid packets since some DNS packets can have an ID of 0

### DIFF
--- a/lib/net/dns/header.rb
+++ b/lib/net/dns/header.rb
@@ -351,7 +351,7 @@ module Net
       # performing security tests.
       #
       def id=(val)
-        if (1..65535).include? val
+        if (0..65535).include? val
           @id = val
         else
           raise ArgumentError, "ID `#{val}' out of range"


### PR DESCRIPTION
I've seen this raise an exception when valid DNS packets come in that have an ID of 0. According to RFC1035, it looks like the ID must be a 16 bit identifier, which can include 0.  I just simple changed the range check for valid IDs from 1..65535 to 0..65535 which should fix when an ID of 0 is used.

If you have any questions please let me know, hope this helps!

Jason
