### PR TITLE
fixing bug on parsing multiple nameservers on different lines

### DIFF
--- a/fixtures/resolv.conf
+++ b/fixtures/resolv.conf
@@ -1,0 +1,4 @@
+search corporate.thoughtworks.com
+nameserver 192.168.1.1
+nameserver 192.168.1.2
+nameserver 192.168.1.3 192.168.1.4

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1059,6 +1059,7 @@ module Net
           self.domain = arr[0].to_s
           self.nameservers = arr[1]
         else
+          nameservers = []
           IO.foreach(@config[:config_file]) do |line|
             line.gsub!(/\s*[;#].*/,"")
             next unless line =~ /\S/
@@ -1068,9 +1069,10 @@ module Net
             when /^\s*search\s+(.*)/
               self.searchlist = $1.split(" ")
             when /^\s*nameserver\s+(.*)/
-              self.nameservers = $1.split(" ")
+              nameservers << $1.split(" ")
             end
           end
+          self.nameservers = nameservers.flatten
         end
       end
 

--- a/test/resolver_test.rb
+++ b/test/resolver_test.rb
@@ -16,6 +16,11 @@ class ResolverTest < Test::Unit::TestCase
     assert_nothing_raised { Net::DNS::Resolver.new({}) }
   end
 
+  def test_initialize_with_multi_name_servers
+    resolver = Net::DNS::Resolver.new({:config_file => 'fixtures/resolv.conf'})
+    assert_equal ['192.168.1.1', '192.168.1.2', '192.168.1.3', '192.168.1.4'], resolver.nameservers
+  end
+
   def test_initialize_with_invalid_config_should_raise_argumenterror
     assert_raises(ArgumentError) { Net::DNS::Resolver.new("") }
     assert_raises(ArgumentError) { Net::DNS::Resolver.new(0) }


### PR DESCRIPTION
Added test & fixture to check parsing of multiple nameservers on different lines of /etc/resolv.conf, as well as multiple nameservers on the same line. Implemented fix.
