### PR TITLE
Bugfix in Packet::query?

### DIFF
--- a/lib/net/dns/packet.rb
+++ b/lib/net/dns/packet.rb
@@ -119,7 +119,7 @@ module Net
 
       # Checks if the packet is a QUERY packet
       def query?
-        @header.opCode == Net::DNS::Header::QUERY
+        @header.query?
       end
 
       # Returns the packet object in binary data, suitable


### PR DESCRIPTION
The opcode doesn't contain anything about the QR. Query/response has been already parsed by Header, so the Header::query? method has been reused.
