### PR TITLE
[names] fix RFC reference 1025 -> 1035

### DIFF
--- a/lib/net/dns/names.rb
+++ b/lib/net/dns/names.rb
@@ -15,7 +15,7 @@ module Net # :nodoc:
       INT16SZ = 2
 
       # Expand a compressed name in a DNS Packet object. Please
-      # see RFC1025 for an explanation of how the compression
+      # see RFC1035 for an explanation of how the compression
       # in DNS packets works, how may it be useful and how should
       # be handled.
       #


### PR DESCRIPTION
http://www.ietf.org/rfc/rfc1025.txt is `TCP AND IP BAKE OFF` which appears to be a coding competition standard for tcp. It does not have the word "compression"

http://www.ietf.org/rfc/rfc1035.txt is `DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION` which talks about `4.1.4. Message compression                                 30`
