### PR TITLE
[rr/a] simplify int ip format parsing

### DIFF
--- a/lib/net/dns/rr/a.rb
+++ b/lib/net/dns/rr/a.rb
@@ -92,9 +92,7 @@ module Net
               when IPAddr
                 input
               when Integer # Address in numeric form
-                tmp = [(input >> 24), (input >> 16) & 0xFF, (input >> 8) & 0xFF, input & 0xFF]
-                tmp = tmp.collect { |x| x.to_s }.join(".")
-                IPAddr.new(tmp)
+                IPAddr.new(input, Socket::AF_INET) # We know we are IPv4
               when String
                 IPAddr.new(input)
               else

--- a/test/rr/a_test.rb
+++ b/test/rr/a_test.rb
@@ -81,7 +81,7 @@ class RRATest < Test::Unit::TestCase
     assert_equal expected, @rr.address
 
     expected = IPAddr.new("64.233.187.90")
-    assert_equal expected, @rr.address = 1089059674
+    assert_equal expected, @rr.address = expected.to_i
     assert_equal expected, @rr.address
 
     expected = IPAddr.new("64.233.187.80")


### PR DESCRIPTION
Tests pass on 1.8.7 and 1.9.3
Looks like there are some test issues on 2.0.0 before this patch.

2.0.0 failures on master look like

```
/opt/boxen/rbenv/versions/2.0.0-p247/bin/ruby -I"lib:test" -I"/opt/boxen/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib" "/opt/boxen/rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_test_loader.rb" test/rr/a_test.rb 
Run options: 

# Running tests:

[ 5/16] RRATest#test_initialize_should_raise_with_invalid_arguments_0 = 0.00 s
  1) Failure:
RRATest#test_initialize_should_raise_with_invalid_arguments_0 [/Users/clundquist/code/net-dns/test/rr/a_test.rb:67]:
[ArgumentError] exception expected, not
Class: <IPAddr::InvalidAddressError>
Message: <"invalid address">
---Backtrace---
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:559:in `in6_addr'
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:496:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `new'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `check_address'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:62:in `subclass_new_from_hash'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:304:in `new_from_hash'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:114:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:355:in `new'
/Users/clundquist/code/net-dns/test/rr/a_test.rb:67:in `block (3 levels) in <class:RRATest>'
---------------

[ 9/16] RRATest#test_initialize_should_raise_with_invalid_arguments_4 = 0.00 s        
  2) Failure:
RRATest#test_initialize_should_raise_with_invalid_arguments_4 [/Users/clundquist/code/net-dns/test/rr/a_test.rb:67]:
[ArgumentError] exception expected, not
Class: <IPAddr::InvalidAddressError>
Message: <"invalid address">
---Backtrace---
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:559:in `in6_addr'
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:496:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `new'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `check_address'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:71:in `subclass_new_from_string'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:278:in `new_from_string'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:112:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:355:in `new'
/Users/clundquist/code/net-dns/test/rr/a_test.rb:67:in `block (3 levels) in <class:RRATest>'
---------------

[10/16] RRATest#test_initialize_should_raise_with_invalid_arguments_5 = 0.00 s        
  3) Failure:
RRATest#test_initialize_should_raise_with_invalid_arguments_5 [/Users/clundquist/code/net-dns/test/rr/a_test.rb:67]:
[ArgumentError] exception expected, not
Class: <IPAddr::InvalidAddressError>
Message: <"invalid address">
---Backtrace---
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:559:in `in6_addr'
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:496:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `new'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `check_address'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:71:in `subclass_new_from_string'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:278:in `new_from_string'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:112:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:355:in `new'
/Users/clundquist/code/net-dns/test/rr/a_test.rb:67:in `block (3 levels) in <class:RRATest>'
---------------

[11/16] RRATest#test_initialize_should_raise_with_invalid_arguments_6 = 0.00 s        
  4) Failure:
RRATest#test_initialize_should_raise_with_invalid_arguments_6 [/Users/clundquist/code/net-dns/test/rr/a_test.rb:67]:
[ArgumentError] exception expected, not
Class: <IPAddr::InvalidAddressError>
Message: <"invalid address">
---Backtrace---
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:559:in `in6_addr'
/opt/boxen/rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/ipaddr.rb:496:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `new'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:99:in `check_address'
/Users/clundquist/code/net-dns/lib/net/dns/rr/a.rb:71:in `subclass_new_from_string'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:278:in `new_from_string'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:112:in `initialize'
/Users/clundquist/code/net-dns/lib/net/dns/rr.rb:355:in `new'
/Users/clundquist/code/net-dns/test/rr/a_test.rb:67:in `block (3 levels) in <class:RRATest>'
---------------

Finished tests in 0.010186s, 1570.7834 tests/s, 3926.9586 assertions/s.               
16 tests, 40 assertions, 4 failures, 0 errors, 0 skips

ruby -v: ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]
```
