### PR TITLE
Simplify nameserver settings (and fix bugs)

### DIFF
--- a/test/resolver_test.rb
+++ b/test/resolver_test.rb
@@ -21,6 +21,16 @@ class ResolverTest < Test::Unit::TestCase
     assert_equal ['192.168.1.1', '192.168.1.2', '192.168.1.3', '192.168.1.4'], resolver.nameservers
   end
 
+  def test_initialize_with_dns
+    resolver = Net::DNS::Resolver.new(:nameservers => "google-public-dns-a.google.com")
+    assert_equal [IPAddr.new('8.8.8.8')], resolver.nameservers
+  end
+
+  def test_initialize_with_dns_array
+    resolver = Net::DNS::Resolver.new(:nameservers => "google-public-dns-a.google.com google-public-dns-b.google.com")
+    assert_equal [IPAddr.new('8.8.8.8'), IPAddr.new('8.8.4.4')], resolver.nameservers
+  end
+
   def test_initialize_with_invalid_config_should_raise_argumenterror
     assert_raises(ArgumentError) { Net::DNS::Resolver.new("") }
     assert_raises(ArgumentError) { Net::DNS::Resolver.new(0) }


### PR DESCRIPTION
This commit makes the method of changing a resolvers nameservers more
functional and less buggy.  For example, using a hostname rather than
ip for setting the nameserver is no longer buggy (the previous
implentation would result in preserving the default nameserver and
would append the inspected form of the IPAddr object of the new nameserver)

This commit consolidates the location of changing @config[:nameservers]
into a single location.
