### PR TITLE
Return answer from query_tcp upon a timeout

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1190,6 +1190,7 @@ module Net
             socket.close
           end
         end
+        ans
       end
 
       def query_udp(packet, packet_data)


### PR DESCRIPTION
query_tcp returns the array of nameservers, but query expects it to return the answer.
