### PR TITLE
Correct warning message when encountering unsupported record types in additionals

### DIFF
--- a/lib/net/dns/packet.rb
+++ b/lib/net/dns/packet.rb
@@ -542,7 +542,7 @@ module Net
               @additional << rrobj
               @logger.debug rrobj.inspect
             rescue NameError => e
-              warn "Net::DNS supported record type: #{e.message}"
+              warn "Net::DNS unsupported record type: #{e.message}"
             end
           end
 


### PR DESCRIPTION
From what I read of this, these are *unsupported* record types.  I encountered this earlier today and wondered why there would be a warning about something that was supported.  Typo.