### PR TITLE
Fix undefined method 'size' errors

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1147,7 +1147,7 @@ module Net
               @logger.info "Receiving #{len} bytes..."
 
               if len == 0
-                @logger.warn "Receiving 0 lenght packet from nameserver #{ns}, trying next."
+                @logger.warn "Receiving 0 length packet from nameserver #{ns}, trying next."
                 next
               end
 
@@ -1170,6 +1170,7 @@ module Net
             socket.close
           end
         end
+        ans
       end
 
       def query_udp(packet, packet_data)


### PR DESCRIPTION
When the list of nameservers is exhausted, previously
`Resolver#query_tcp` was returning the list of nameservers. Fix this by
returning the last received payload from the server.

Closes #46
