### PR TITLE
Handle short data

### DIFF
--- a/lib/net/dns/question.rb
+++ b/lib/net/dns/question.rb
@@ -173,6 +173,8 @@ module Net
       end
 
       def new_from_binary(data)
+        raise NameInvalid if data.size <= 4
+
         str, type, cls = data.unpack("a#{data.size - 4}nn")
         @qName = build_qName(str)
         @qType = Net::DNS::RR::Types.new type

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -43,6 +43,15 @@ class QuestionTest < Minitest::Test
       Net::DNS::Question.parse([])
     end
     assert_raises(ArgumentError) do
+      Net::DNS::Question.parse("[]")
+    end
+    assert_raises(ArgumentError) do
+      Net::DNS::Question.parse("12344")
+    end
+    assert_raises(ArgumentError) do
+      Net::DNS::Question.parse("12345")
+    end
+    assert_raises(ArgumentError) do
       Net::DNS::Question.parse("test")
     end
   end


### PR DESCRIPTION
If the number of bytes <= 4, `unpack` was being called with zero or negative numbers.