### PR TITLE
Add dependency on `logger` gem

### DIFF
--- a/net-dns.gemspec
+++ b/net-dns.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   end
   s.require_paths = ["lib"]
   s.extra_rdoc_files = %w(LICENSE.txt)
+  s.add_dependency "logger"
 end


### PR DESCRIPTION
Hi, thanks for this project! This PR fixes a warning with Ruby 3.4.

```text
/Users/user/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/net-dns-0.20.0/lib/net/dns/packet.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```